### PR TITLE
Avoid duplicating extract logs in interactive mode

### DIFF
--- a/src/commands/extract.tsx
+++ b/src/commands/extract.tsx
@@ -73,7 +73,7 @@ async function runInteractiveWizard(
   baseOptions: ExtractOptions,
   ctx: CLIContext,
 ): Promise<InteractiveWizardResult> {
-  const inkLogger = createInkLogger({ baseLogger: ctx.logger });
+  const inkLogger = createInkLogger({ baseLogger: ctx.logger, mirrorToBaseLogger: false });
   let finalResult: ExtractResult | null = null;
   let cancelled = false;
   let finalExecOptions: ExecuteOptions | null = null;

--- a/src/ui/logger-adapter.ts
+++ b/src/ui/logger-adapter.ts
@@ -21,11 +21,13 @@ function createLogEntry(level: LogLevel, message: string): LogEntry {
 export interface CreateInkLoggerOptions {
   baseLogger?: Logger;
   historyLimit?: number;
+  mirrorToBaseLogger?: boolean;
 }
 
 export function createInkLogger({
   baseLogger,
   historyLimit = 200,
+  mirrorToBaseLogger = true,
 }: CreateInkLoggerOptions = {}): InkLogger {
   let entries: LogEntry[] = [];
   const listeners = new Set<(entries: LogEntry[]) => void>();
@@ -37,25 +39,27 @@ export function createInkLogger({
     }
   }
 
+  const shouldMirror = Boolean(baseLogger) && mirrorToBaseLogger;
+
   const inkLogger: InkLogger = {
     info: (msg: string) => {
       const norm = normalizeMessage(msg);
-      baseLogger?.info(norm);
+      if (shouldMirror) baseLogger?.info(norm);
       emit(createLogEntry('info', norm));
     },
     warn: (msg: string) => {
       const norm = normalizeMessage(msg);
-      baseLogger?.warn(norm);
+      if (shouldMirror) baseLogger?.warn(norm);
       emit(createLogEntry('warn', norm));
     },
     error: (msg: string | Error) => {
       const norm = normalizeMessage(msg);
-      baseLogger?.error(norm);
+      if (shouldMirror) baseLogger?.error(norm);
       emit(createLogEntry('error', norm));
     },
     debug: (msg: string) => {
       const norm = normalizeMessage(msg);
-      baseLogger?.debug(norm);
+      if (shouldMirror) baseLogger?.debug(norm);
       emit(createLogEntry('debug', norm));
     },
     isVerbose: () => baseLogger?.isVerbose?.() ?? false,


### PR DESCRIPTION
## Summary
- add a mirrorToBaseLogger option to the Ink logger adapter so mirroring can be disabled
- stop forwarding interactive tz extract wizard logs to the base CLI logger to avoid duplicate console output

## Testing
- pnpm vitest run tests/ui/extract-wizard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e10ded4fa08321ad1a8d4970c7546e