### PR TITLE
Update default extract output directory to my-first-package

### DIFF
--- a/src/commands/extract.tsx
+++ b/src/commands/extract.tsx
@@ -35,7 +35,7 @@ function deriveDefaultName(fromDir: string): string {
 }
 
 function deriveDefaultOut(fromDir: string): string {
-  return path.join(fromDir, 'extracted-package');
+  return path.join(fromDir, 'my-first-package');
 }
 
 interface ExtractArgs {

--- a/tests/integration/extract-interactive.test.ts
+++ b/tests/integration/extract-interactive.test.ts
@@ -97,11 +97,11 @@ describe('tz extract (interactive wizard)', () => {
       );
 
       const suffix = '-custom';
-      const expectedOutDir = path.join(project.root, `extracted-package${suffix}`);
+      const expectedOutDir = path.join(project.root, `my-first-package${suffix}`);
 
       const baseOptions: ExtractOptions = {
         from: project.root,
-        out: path.join(project.root, 'extracted-package'),
+        out: path.join(project.root, 'my-first-package'),
         name: `@local/${slugifySegment(path.basename(project.root) || 'project')}`,
         version: '1.0.0',
         includeClaudeLocal: false,
@@ -159,7 +159,7 @@ describe('tz extract (interactive wizard)', () => {
       child.stdin.write('\t');
       await waitForText('Step 3/6');
       child.stdin.write(suffix);
-      await waitForText(`extracted-package${suffix}`);
+      await waitForText(`my-first-package${suffix}`);
       child.stdin.write('\t');
       await waitForText('Step 4/6');
       child.stdin.write('\t');


### PR DESCRIPTION
## Summary
- change the default extract output directory name to `my-first-package`
- update integration test expectations to reflect the new default directory

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10ecea6d08321b1a5c04b0541af37