### PR TITLE
Switch extract options step to selectable list

### DIFF
--- a/tests/ui/extract-wizard.test.tsx
+++ b/tests/ui/extract-wizard.test.tsx
@@ -190,6 +190,8 @@ describe('ExtractWizard', () => {
     stdin.write('\r');
     await pause();
     await expectFrameContains(lastFrame, 'Extract • Step 5/6 — Toggle Options');
+    await expectFrameContains(lastFrame, 'Space • Toggle');
+    await expectFrameNotContains(lastFrame, 'L • Claude local');
 
     stdin.write('\r');
     await pause();


### PR DESCRIPTION
## Summary
- replace the extract wizard options step UI with the shared selectable list and cursor navigation hints
- update option toggle handling to support arrow navigation with space toggles while still triggering re-analysis when needed
- adjust the extract wizard UI test expectations for the new hints and lack of legacy key commands

## Testing
- pnpm test tests/ui/extract-wizard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e10eaff0588321919b67171a25e64c