### PR TITLE
Remove extract wizard help log

### DIFF
--- a/src/ui/extract/ExtractWizard.tsx
+++ b/src/ui/extract/ExtractWizard.tsx
@@ -522,11 +522,6 @@ export function ExtractWizard({
       return;
     }
 
-    if (lower === '?') {
-      pushLog('info', 'Help: run `tz extract --help` for documentation.');
-      return;
-    }
-
     switch (currentStep) {
       case 'artifacts': {
         if (key.upArrow) {


### PR DESCRIPTION
## Summary
- remove the keyboard shortcut that surfaced the CLI help message in the extract wizard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10ea1a2a48321b93adfb25cdc01f6