### PR TITLE
Default interactive extract wizard version to 0.0.0

### DIFF
--- a/src/commands/extract.tsx
+++ b/src/commands/extract.tsx
@@ -50,13 +50,15 @@ interface ExtractArgs {
   interactive?: boolean;
 }
 
-function buildInteractiveBaseOptions(args: ExtractArgs): ExtractOptions {
+export const DEFAULT_PACKAGE_VERSION = '0.0.0';
+
+export function buildInteractiveBaseOptions(args: ExtractArgs): ExtractOptions {
   const fromAbs = path.resolve(args.from ?? process.cwd());
   return {
     from: fromAbs,
     out: args.out ? path.resolve(args.out) : deriveDefaultOut(fromAbs),
     name: args.name ?? deriveDefaultName(fromAbs),
-    version: args.pkgVersion ?? '1.0.0',
+    version: args.pkgVersion ?? DEFAULT_PACKAGE_VERSION,
     includeClaudeLocal: Boolean(args.includeClaudeLocal),
     includeClaudeUser: Boolean(args.includeClaudeUser),
     force: Boolean(args.force),

--- a/tests/unit/commands/extract.interactive-options.test.ts
+++ b/tests/unit/commands/extract.interactive-options.test.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_PACKAGE_VERSION,
+  buildInteractiveBaseOptions,
+} from '../../../src/commands/extract';
+
+describe('buildInteractiveBaseOptions', () => {
+  it('uses 0.0.0 as the default package version', () => {
+    const options = buildInteractiveBaseOptions({ from: '/tmp/project' });
+
+    expect(options.version).toBe(DEFAULT_PACKAGE_VERSION);
+  });
+
+  it('preserves an explicit pkgVersion argument', () => {
+    const options = buildInteractiveBaseOptions({
+      from: '/tmp/project',
+      pkgVersion: '3.2.1',
+    });
+
+    expect(options.version).toBe('3.2.1');
+  });
+
+  it('derives defaults relative to the provided project root', () => {
+    const options = buildInteractiveBaseOptions({ from: '/tmp/project' });
+
+    expect(options.from).toBe(path.resolve('/tmp/project'));
+    expect(options.out).toBe(path.join(path.resolve('/tmp/project'), 'extracted-package'));
+  });
+});


### PR DESCRIPTION
## Summary
- default the interactive extract wizard to start at package version 0.0.0 when no version is provided
- export the helper used to build wizard options and cover the defaulting behavior with unit tests

## Testing
- pnpm exec vitest run tests/unit/commands/extract.interactive-options.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e10e4a718c832180b08ea946278538