### PR TITLE
fix(extract): include selected MCP configs in extract

### DIFF
--- a/src/core/extract/mcp/codex-config.ts
+++ b/src/core/extract/mcp/codex-config.ts
@@ -56,6 +56,11 @@ export function parseCodexMcpServers(
         args: sanitizedArgs,
         env: sanitizedEnv ?? {},
       },
+      config: {
+        command: rewritePath(commandRaw, projectRootAbs),
+        ...(sanitizedArgs.length > 0 ? { args: sanitizedArgs } : {}),
+        ...(sanitizedEnv && Object.keys(sanitizedEnv).length > 0 ? { env: sanitizedEnv } : {}),
+      },
     });
   }
 

--- a/src/core/extract/mcp/project-config.ts
+++ b/src/core/extract/mcp/project-config.ts
@@ -55,6 +55,11 @@ export function parseProjectMcpServers(
         args: sanitizedArgs,
         env: sanitizedEnv ?? {},
       },
+      config: {
+        command: rewritePath(commandRaw, projectRootAbs),
+        ...(sanitizedArgs.length > 0 ? { args: sanitizedArgs } : {}),
+        ...(sanitizedEnv && Object.keys(sanitizedEnv).length > 0 ? { env: sanitizedEnv } : {}),
+      },
     });
   }
 

--- a/src/core/extract/types.ts
+++ b/src/core/extract/types.ts
@@ -53,6 +53,7 @@ export interface MCPServerPlan {
     args: string[];
     env: Record<string, string>;
   };
+  config: Record<string, unknown>;
 }
 
 export interface ExtractPlan {

--- a/src/ui/extract/ExtractWizard.tsx
+++ b/src/ui/extract/ExtractWizard.tsx
@@ -924,6 +924,9 @@ export function ExtractWizard({
     if (currentStep === 'metadata') {
       hints.push({ key: 'Tab', label: 'Next field' });
     }
+    if (currentStep === 'preview') {
+      hints.push({ key: 'C', label: 'Copy summary', hidden: !reviewSummary });
+    }
     hints.push({ key: 'V', label: logsVisible ? 'Hide logs' : 'Show logs' });
     hints.push({ key: '?', label: 'Help' });
     return hints;
@@ -942,6 +945,7 @@ export function ExtractWizard({
     stepIndex,
     mcpItems.length,
     subagentItems.length,
+    reviewSummary,
   ]);
 
   if (status === 'completed' && result) {

--- a/tests/ui/extract-wizard.test.tsx
+++ b/tests/ui/extract-wizard.test.tsx
@@ -69,6 +69,7 @@ function createPlan(overrides: Partial<ExtractPlan> = {}): ExtractPlan {
         source: 'codex',
         origin: '~/.codex/config.toml',
         definition: { command: 'run-embeddings', args: [], env: {} },
+        config: { command: 'run-embeddings' },
       },
       {
         id: 'project:search',
@@ -76,6 +77,7 @@ function createPlan(overrides: Partial<ExtractPlan> = {}): ExtractPlan {
         source: 'project',
         origin: '/projects/demo/.mcp.json',
         definition: { command: './scripts/search.sh', args: [], env: {} },
+        config: { command: './scripts/search.sh' },
       },
     ],
     ...overrides,

--- a/tests/unit/core/extract-plan.test.ts
+++ b/tests/unit/core/extract-plan.test.ts
@@ -47,6 +47,8 @@ async function setupProject(): Promise<TempPaths> {
         coder: {
           command: path.join(project, 'bin', 'coder'),
           args: ['--workspace', path.join(project, 'workspace')],
+          transport: { type: 'stdio' },
+          metadata: { keep: 'yes' },
         },
       },
       null,
@@ -191,6 +193,12 @@ describe('executeExtract', () => {
     const mcpJson = mcpRaw && typeof mcpRaw === 'object' ? (mcpRaw as Record<string, unknown>) : {};
     expect(Object.keys(mcpJson)).toEqual(['coder', 'embeddings', 'search']);
     expect(JSON.stringify(mcpJson)).not.toContain(paths.project);
+    const coder =
+      mcpJson.coder && typeof mcpJson.coder === 'object'
+        ? (mcpJson.coder as Record<string, unknown>)
+        : {};
+    expect(coder.transport).toEqual({ type: 'stdio' });
+    expect(coder.metadata).toEqual({ keep: 'yes' });
     expect(result.summary.outputs).toContain('templates/claude/mcp_servers.json.hbs');
 
     // Legacy performExtract should still succeed and produce same manifest when everything included
@@ -242,5 +250,11 @@ describe('executeExtract', () => {
     ) as unknown;
     const mcpJson = mcpRaw && typeof mcpRaw === 'object' ? (mcpRaw as Record<string, unknown>) : {};
     expect(Object.keys(mcpJson)).toEqual(['coder', 'search']);
+    const coder =
+      mcpJson.coder && typeof mcpJson.coder === 'object'
+        ? (mcpJson.coder as Record<string, unknown>)
+        : {};
+    expect(coder.transport).toEqual({ type: 'stdio' });
+    expect(coder.metadata).toEqual({ keep: 'yes' });
   });
 });


### PR DESCRIPTION
## Summary
- preserve sanitized MCP server definitions when generating extract packages so the wizard selection carries into the bundle
- expose the preview copy-summary shortcut and align NodeNext import extensions
- expand unit/UI coverage to assert MCP metadata preservation and keep fixtures consistent

## Testing
- pnpm run build
- pnpm run typecheck
- pnpm run lint:fix
- pnpm run format
- pnpm test tests/unit/core/extract-plan.test.ts
- pnpm test tests/ui/extract-wizard.test.tsx
- pnpm test *(fails: local dummy registry health checks / __dirname resolution under ESM)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f1061e548321a9ffb68774750234