### PR TITLE
fix(logs): Improve logging and error handling in sea-fetcher and compression

### DIFF
--- a/src/runtime/sea-fetcher.ts
+++ b/src/runtime/sea-fetcher.ts
@@ -248,6 +248,7 @@ export async function ensureSeaBinary(options: EnsureSeaBinaryOptions = {}): Pro
     const downloadPath = path.join(tempDir, artifactName);
 
     try {
+      console.error(`Downloading tz ${cliVersion} for ${target.target}...`);
       await downloadWithRetries(url, downloadPath, targetEntry.size, retries);
       const digest = await hashFile(downloadPath);
       if (digest.toLowerCase() !== targetEntry.sha256.toLowerCase()) {
@@ -265,6 +266,7 @@ export async function ensureSeaBinary(options: EnsureSeaBinaryOptions = {}): Pro
       // Sign the binary on macOS after decompression to prevent Gatekeeper from blocking it
       await signBinaryOnMacOS(binaryPath, platform);
 
+      console.error('Download finished. Booting tz...');
       return binaryPath;
     } finally {
       await fs.rm(downloadPath, { force: true }).catch(() => {});

--- a/tests/unit/runtime/sea-fetcher.test.ts
+++ b/tests/unit/runtime/sea-fetcher.test.ts
@@ -74,6 +74,7 @@ describe('ensureSeaBinary', () => {
 
     const fetchMock = vi.fn(() => Promise.resolve(new Response(artifactData)));
     vi.stubGlobal('fetch', fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { ensureSeaBinary } = await import('../../../src/runtime/sea-fetcher');
     const binaryPath: string = await ensureSeaBinary({
@@ -92,6 +93,8 @@ describe('ensureSeaBinary', () => {
     const binary = await fs.readFile(binaryPath, 'utf8');
     expect(binary).toBe('sea-binary-payload');
     expect(binaryPath).toContain(path.join(cacheDir, '0.3.1', 'darwin-arm64'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Downloading tz 0.3.1 for darwin-arm64...');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Download finished. Booting tz...');
   });
 
   it('throws when downloaded artifact hash mismatches the manifest', async () => {


### PR DESCRIPTION
Added console error logs to indicate download progress in ensureSeaBinary. Enhanced decompressWithCli to capture and report zstd stderr output on failure. Updated unit tests to verify new logging behavior.