### PR TITLE
fix: default extract version starts at 0.0.0

### DIFF
--- a/src/commands/extract.tsx
+++ b/src/commands/extract.tsx
@@ -88,7 +88,7 @@ export async function buildInteractiveBaseOptions(
     from: fromAbs,
     out: defaultOut,
     name,
-    version: args.pkgVersion ?? '1.0.0',
+    version: args.pkgVersion ?? '0.0.0',
     includeClaudeLocal: Boolean(args.includeClaudeLocal),
     includeClaudeUser: Boolean(args.includeClaudeUser),
     force: Boolean(args.force),
@@ -169,7 +169,7 @@ export function registerExtractCommand(
     .option('--from <path>', 'Source directory (project root or .claude)')
     .option('--out <path>', 'Output directory for the new package')
     .option('--name <name>', 'Package name, e.g., @user/ctx')
-    .option('--pkg-version <semver>', 'Package version, e.g., 1.0.0')
+    .option('--pkg-version <semver>', 'Package version, e.g., 0.0.0')
     .option('--include-claude-local', 'Include .claude/settings.local.json (sanitized)', false)
     .option('--include-claude-user', 'Include user-scoped ~/.claude.json (sanitized)', false)
     .option('--force', 'Overwrite non-empty output directory', false)

--- a/src/ui/extract/ExtractWizard.tsx
+++ b/src/ui/extract/ExtractWizard.tsx
@@ -226,7 +226,7 @@ export function ExtractWizard({
       return error instanceof Error ? error.message : String(error);
     }
     if (!semver.valid(options.version.trim())) {
-      return 'Version must be valid semver (e.g., 1.0.0)';
+      return 'Version must be valid semver (e.g., 0.0.0)';
     }
     return null;
   }, [options.name, options.version]);
@@ -1065,7 +1065,7 @@ export function ExtractWizard({
                   setOptions((prev: ExtractOptions) => ({ ...prev, version: value }))
                 }
               />
-              <Text dimColor>Use semantic versioning, e.g., 1.0.0.</Text>
+              <Text dimColor>Use semantic versioning, e.g., 0.0.0.</Text>
               {metadataError ? <Text color="red">⚠ {metadataError}</Text> : null}
             </Box>
           </Box>

--- a/tests/ui/extract-summary.test.tsx
+++ b/tests/ui/extract-summary.test.tsx
@@ -7,7 +7,7 @@ const baseOptions: ExtractOptions = {
   from: '/projects/demo',
   out: '/projects/demo/out',
   name: '@demo/pkg',
-  version: '1.0.0',
+  version: '0.0.0',
   includeClaudeLocal: false,
   includeClaudeUser: false,
   dryRun: false,
@@ -80,7 +80,7 @@ describe('buildReviewSummary', () => {
 
     expect(summary.destination.path).toBe('/projects/demo/out');
     expect(summary.destination.packageName).toBe('@demo/pkg');
-    expect(summary.destination.version).toBe('1.0.0');
+    expect(summary.destination.version).toBe('0.0.0');
     expect(summary.destination.dryRun).toBe(true);
     expect(summary.destination.force).toBe(true);
   });

--- a/tests/ui/extract-wizard.test.tsx
+++ b/tests/ui/extract-wizard.test.tsx
@@ -14,7 +14,7 @@ const baseOptions: ExtractOptions = {
   from: '/projects/demo',
   out: '/projects/demo/out',
   name: '@demo/pkg',
-  version: '1.0.0',
+  version: '0.0.0',
   includeClaudeLocal: false,
   includeClaudeUser: false,
   dryRun: false,
@@ -244,7 +244,7 @@ describe('ExtractWizard', () => {
     stdin.write('\t');
     await expectFrameContains(lastFrame, 'Extract • Step 4/6 — Confirm Package Metadata');
 
-    await expectFrameContains(lastFrame, 'Version must be valid semver (e.g., 1.0.0)');
+    await expectFrameContains(lastFrame, 'Version must be valid semver (e.g., 0.0.0)');
     await expectFrameContains(lastFrame, 'Enter • Continue (disabled)');
 
     stdin.write('\t');
@@ -256,7 +256,7 @@ describe('ExtractWizard', () => {
     stdin.write('1.2.3');
 
     await pause();
-    await expectFrameNotContains(lastFrame, 'Version must be valid semver (e.g., 1.0.0)');
+    await expectFrameNotContains(lastFrame, 'Version must be valid semver (e.g., 0.0.0)');
     await expectFrameContains(lastFrame, 'Enter • Continue');
 
     stdin.write('\r');

--- a/tests/unit/commands/extract.interactive-options.test.ts
+++ b/tests/unit/commands/extract.interactive-options.test.ts
@@ -34,11 +34,11 @@ function createMockContext(): CLIContext {
 }
 
 describe('buildInteractiveBaseOptions', () => {
-  it('uses 1.0.0 as the default package version', async () => {
+  it('uses 0.0.0 as the default package version', async () => {
     const ctx = createMockContext();
     const options = await buildInteractiveBaseOptions({ from: '/tmp/project' }, ctx);
 
-    expect(options.version).toBe('1.0.0');
+    expect(options.version).toBe('0.0.0');
   });
 
   it('preserves an explicit pkgVersion argument', async () => {


### PR DESCRIPTION
## Summary
- default the extract command's package version to 0.0.0 and adjust CLI guidance
- update the extract wizard copy to reference the new starting version and keep tests in sync

## Testing
- pnpm test tests/unit/commands/extract.interactive-options.test.ts
- pnpm test tests/ui/extract-wizard.test.tsx
- pnpm test tests/ui/extract-summary.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e52dfaab4c83218e75de4fdf22e11f